### PR TITLE
FIX, line nemůže začínat a končit ve stejném bodě

### DIFF
--- a/src/net/trdlo/zelda/guan/OrthoCamera.java
+++ b/src/net/trdlo/zelda/guan/OrthoCamera.java
@@ -522,7 +522,7 @@ class OrthoCamera {
 			world.points.add(oldB);
 			world.lines.add(insertedLine);
 			insertedLine = Line.constructFromTwoPoints(oldB, mP);
-		} else {
+		} else if (insertedLine.getA() != wP) {
 			insertedLine.setB(wP);
 			world.lines.add(insertedLine);
 			insertedLine = null;


### PR DESCRIPTION
Když jsem 2x za sebou zmáčkl mezerník, vytvořila se line se stejným počátečním i koncovým bodem. Nevadilo to do té doby, než jsem se to pokusil smazat. Pak na mě vylítla runtime exception `Line was not a listener of this point!`