### PR TITLE
Hodina 2016 01 14

### DIFF
--- a/src/net/trdlo/zelda/guan/EditorView.java
+++ b/src/net/trdlo/zelda/guan/EditorView.java
@@ -60,6 +60,7 @@ class EditorView extends AbstractView {
 	private StringBuilder descBuilder;
 
 	Polygon horizPoly;
+	boolean horizontEnabled = true;
 
 	public EditorView(World world, double x, double y, int zoom) {
 		setWorld(world, x, y, zoom);
@@ -91,10 +92,22 @@ class EditorView extends AbstractView {
 	}
 
 	private void readAsynchronoutInput() {
-//		if (ZeldaFrame.isPressed(KeyEvent.VK_ADD)) {
-//
-//		}
-
+		if (ZeldaFrame.isPressed(KeyEvent.VK_LEFT)) {
+			world.players.iterator().next().orientation -= 0.3;
+		}
+		if (ZeldaFrame.isPressed(KeyEvent.VK_RIGHT)) {
+			world.players.iterator().next().orientation += 0.31;
+		}
+		if (ZeldaFrame.isPressed(KeyEvent.VK_UP)) {
+			Player p = world.players.iterator().next();
+			p.x += Math.cos(p.orientation) * p.speed;
+			p.y += Math.sin(p.orientation) * p.speed;
+		}
+		if (ZeldaFrame.isPressed(KeyEvent.VK_DOWN)) {
+			Player p = world.players.iterator().next();
+			p.x -= Math.cos(p.orientation) * p.speed;
+			p.y -= Math.sin(p.orientation) * p.speed;
+		}
 	}
 
 	@Override
@@ -298,7 +311,9 @@ class EditorView extends AbstractView {
 			renderCrossingDebug(graphics, line);
 		}
 
-		if (horizPoly != null) {
+		if (horizontEnabled) {
+			horizPoly = convertLineListToPoly(new Horizont(world.lines, world.players.iterator().next()).computeHorizont());
+
 			Player player = world.players.iterator().next();
 			Point pp = new Point(player.x, player.y);
 
@@ -313,7 +328,7 @@ class EditorView extends AbstractView {
 			if ((System.nanoTime() / 1000000000L & 1) == 0) {
 				startAngle += (int) ((System.nanoTime() % 1000000000L) * 360 / 1000000000L);
 			}
-			graphics.drawArc(worldToViewX(pp.x - player.vDist), worldToViewY(pp.y - player.vDist), (int) (player.vDist * 2), (int) (player.vDist * 2), startAngle, -NU.radToDeg(player.fov));
+			graphics.drawArc(worldToViewX(pp.x - player.vDist), worldToViewY(pp.y - player.vDist), (int) (player.vDist * 2 * zoomCoef()), (int) (player.vDist * 2 * zoomCoef()), startAngle, -NU.radToDeg(player.fov));
 		}
 
 		for (Point point : world.points) {
@@ -925,10 +940,6 @@ class EditorView extends AbstractView {
 		return new Polygon(xPoints, yPoints, count);
 	}
 
-	private void testHorizont() {
-		horizPoly = convertLineListToPoly(new Horizont(world.lines, world.players.iterator().next()).computeHorizont());
-	}
-
 	@Override
 	public boolean keyTyped(KeyEvent e) {
 		if (isTyping()) {
@@ -968,14 +979,8 @@ class EditorView extends AbstractView {
 				case 't':
 					initTypingDesc();
 					break;
-				case 'h':
-					testHorizont();
-					break;
-				case 'j':
-					world.players.iterator().next().orientation -= 0.3;
-					break;
-				case 'k':
-					world.players.iterator().next().orientation += 0.31;
+				case 'f':
+					horizontEnabled = !horizontEnabled;
 					break;
 				default:
 					return false;
@@ -986,7 +991,7 @@ class EditorView extends AbstractView {
 
 	@Override
 	public boolean keyPressed(KeyEvent e) {
-		switch (e.getKeyChar()) {
+		switch (e.getKeyCode()) {
 			case KeyEvent.VK_ESCAPE:
 				return cancelOperation();
 			case KeyEvent.VK_DELETE:
@@ -1005,7 +1010,16 @@ class EditorView extends AbstractView {
 
 	@Override
 	public boolean mouseClicked(MouseEvent e) {
-		return false;
+		switch (e.getButton()) {
+			case MouseEvent.BUTTON2:
+				Player p = world.players.iterator().next();
+				p.x = viewToWorldX(e.getX());
+				p.y = viewToWorldY(e.getY());
+				break;
+			default:
+				return false;
+		}
+		return true;
 	}
 
 	@Override

--- a/src/net/trdlo/zelda/guan/Horizont.java
+++ b/src/net/trdlo/zelda/guan/Horizont.java
@@ -48,7 +48,16 @@ public class Horizont {
 		points = new TreeSet<>(new Comparator<Point>() {
 			@Override
 			public int compare(Point o1, Point o2) {
-				return o1.tempAngle < o2.tempAngle ? -1 : (o1.tempAngle > o2.tempAngle ? 1 : o1.hashCode() - o2.hashCode());
+				if (o1.tempAngle != o2.tempAngle) {
+					return o1.tempAngle < o2.tempAngle ? -1 : 1;
+				} else {
+					double distDiff = o1.tempDistSqr - o2.tempDistSqr;
+					if (distDiff != 0) {
+						return distDiff < 0 ? -1 : 1;
+					} else {
+						return o1.hashCode() - o2.hashCode();
+					}
+				}
 			}
 		});
 	}
@@ -194,7 +203,7 @@ public class Horizont {
 		int limit = 0;
 		for (Point point : points) {
 			limit++;
-			if (limit > 1) {
+			if (limit >= 1) {
 				limit--;
 			}
 			if (currentRC.line == null) {

--- a/src/net/trdlo/zelda/guan/Line.java
+++ b/src/net/trdlo/zelda/guan/Line.java
@@ -378,8 +378,8 @@ public final class Line {
 	public double getHalfNormalizedCosAlpha(Point point) {
 		double nx = A.y - B.y;
 		double ny = B.x - A.x;
-		double vx = point.x - A.x;
-		double vy = point.y - A.y;
+		double vx = point.x - B.x;
+		double vy = point.y - B.y;
 		double vLen = Math.sqrt(vx * vx + vy * vy);
 
 		return nx * (vy / vLen) - (vx / vLen) * ny;

--- a/src/net/trdlo/zelda/guan/Player.java
+++ b/src/net/trdlo/zelda/guan/Player.java
@@ -5,12 +5,13 @@ import net.trdlo.zelda.NU;
 public class Player {
 
 	public Player() {
-		fov = NU.degToRad(359);
+		fov = NU.degToRad(120);
 		vDist = 321;
 		vDistSqr = NU.sqr(vDist);
 	}
 
 	public double x, y;
+	public static final int speed = 5;
 	public double vx, vy;
 	public double orientation;
 	public double fov, vDist, vDistSqr;

--- a/src/net/trdlo/zelda/guan/Point.java
+++ b/src/net/trdlo/zelda/guan/Point.java
@@ -14,7 +14,7 @@ import net.trdlo.zelda.NU;
 public final class Point {
 
 	public static final Pattern PAT_POINT = Pattern.compile("^\\s*Point\\s+(\\d+)\\s*\\[\\s*([-+]?\\d*\\.?\\d+)\\s*;\\s*([-+]?\\d*\\.?\\d+)\\s*\\]\\s*(.*)\\z", Pattern.CASE_INSENSITIVE);
-	public static final int DISPLAY_SIZE = 8;
+	public static final int DISPLAY_SIZE = 15;
 	public static final int HIGHLIGHT_MAX_DISTANCE = 8;
 
 	public static final Stroke DEFAULT_STROKE = new BasicStroke(1);


### PR DESCRIPTION
Další vylepšení horizontu
Vyřešen případ, kdy vůči playerovi je bod a line na přímce. Řešeno je
úpravou komparátoru v množině
Horizont se počítá a vykresluje v každém renderu a nově se ovládá klávesou
f
Stisk kolečka myši přesune playera, otáčí se a pohybuje šipkami
Opraveno vykresování kružnice kolem horizontu
Opravena metoda getHalfNormalizedCosAlpha
Zvětšen point pro pohodlí debugerů